### PR TITLE
feat: configure Strapi base URL

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-REACT_APP_STRAPI_URL=http://localhost:1337
+REACT_APP_STRAPI_URL=http://127.0.0.1:1337


### PR DESCRIPTION
## Summary
- configure Strapi base URL via REACT_APP_STRAPI_URL

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689d082ab308832fb54370db02053191