### PR TITLE
Add feedback email submission endpoint

### DIFF
--- a/backend/controllers/feedbackController.js
+++ b/backend/controllers/feedbackController.js
@@ -1,0 +1,30 @@
+const nodemailer = require('nodemailer');
+require('dotenv').config();
+
+exports.sendFeedback = async (req, res) => {
+  const { name, message, rating } = req.body;
+
+  try {
+    const transporter = nodemailer.createTransport({
+      service: 'gmail',
+      auth: {
+        user: process.env.EMAIL_USER,
+        pass: process.env.EMAIL_PASS,
+      },
+    });
+
+    const mailOptions = {
+      from: process.env.EMAIL_USER,
+      to: process.env.EMAIL_TO || 'lorimarfitness@gmail.com',
+      subject: 'New Feedback Message',
+      text: `Name: ${name || 'Anonymous'}\nRating: ${rating}\nMessage:\n${message}`,
+    };
+
+    await transporter.sendMail(mailOptions);
+
+    res.status(200).json({ message: 'Feedback sent' });
+  } catch (error) {
+    console.error('Feedback send error:', error);
+    res.status(500).json({ error: 'Failed to send feedback' });
+  }
+};

--- a/backend/routes/feedbackRoutes.js
+++ b/backend/routes/feedbackRoutes.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const router = express.Router();
+const { sendFeedback } = require('../controllers/feedbackController');
+
+router.post('/', sendFeedback);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 const cors = require('cors');
 const dotenv = require('dotenv');
 const planRoutes = require('./routes/planRoutes');
+const feedbackRoutes = require('./routes/feedbackRoutes');
 
 dotenv.config();
 const app = express();
@@ -10,6 +11,7 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 app.use('/api/plans', planRoutes);
+app.use('/api/feedback', feedbackRoutes);
 
 mongoose
   .connect(process.env.MONGO_URI, { useNewUrlParser: true, useUnifiedTopology: true })

--- a/src/pages/Feedback.jsx
+++ b/src/pages/Feedback.jsx
@@ -3,10 +3,25 @@ import '../Styles/harmonized-styles.css';
 
 const Feedback = () => {
   const [submitted, setSubmitted] = useState(false);
+  const [formData, setFormData] = useState({ name: '', message: '', rating: '' });
 
-  const handleSubmit = (e) => {
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    setSubmitted(true);
+    try {
+      await fetch('/api/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formData),
+      });
+      setSubmitted(true);
+    } catch (err) {
+      console.error('Feedback submit error:', err);
+    }
   };
 
   return (
@@ -20,10 +35,30 @@ const Feedback = () => {
         </div>
       ) : (
         <form className="feedback-form-girly" onSubmit={handleSubmit}>
-          <input type="text" placeholder="Your Name (optional)" />
-          <textarea placeholder="Tell us everything 💌" rows="4" required></textarea>
-          <select defaultValue="">
-            <option value="" disabled>How are we doing? 💬</option>
+          <input
+            type="text"
+            name="name"
+            placeholder="Your Name (optional)"
+            value={formData.name}
+            onChange={handleChange}
+          />
+          <textarea
+            name="message"
+            placeholder="Tell us everything 💌"
+            rows="4"
+            required
+            value={formData.message}
+            onChange={handleChange}
+          ></textarea>
+          <select
+            name="rating"
+            value={formData.rating}
+            onChange={handleChange}
+            required
+          >
+            <option value="" disabled>
+              How are we doing? 💬
+            </option>
             <option value="5">🌟🌟🌟🌟🌟 - Amazing!</option>
             <option value="4">🌟🌟🌟🌟 - Great!</option>
             <option value="3">🌟🌟🌟 - Okay</option>


### PR DESCRIPTION
## Summary
- capture feedback form data on frontend and post to backend
- add Express route and controller to send feedback email via Nodemailer
- register feedback API endpoint on server

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689e5c6cb02c832f9e2ed41c34fe73e8