### PR TITLE
Fix event image path and streamline styles

### DIFF
--- a/src/Styles/harmonized-styles.css
+++ b/src/Styles/harmonized-styles.css
@@ -362,6 +362,22 @@ code {
   box-shadow: 0 10px 24px rgba(255, 0, 160, 0.3);
 }
 
+/* === Utility Classes === */
+.muted {
+  opacity: 0.75;
+}
+.small {
+  font-size: 0.875rem;
+}
+.card {
+  background: #fff;
+  border-radius: 14px;
+  box-shadow:
+    0 12px 30px rgba(255, 0, 120, 0.08),
+    0 4px 14px rgba(0, 0, 0, 0.06);
+  padding: 1rem;
+}
+
 /* === MainLayout.css === */
 /* src/layout/MainLayout.css */
 
@@ -377,67 +393,7 @@ code {
   overflow-y: auto;
   background-color: #fff0f6;
 }
-
-/* === Blog.css === */
-.blog-post {
-  margin: 40px auto;
-  padding: 20px;
-  border-radius: 12px;
-  background: #fff0f6;
-  font-family: "Quicksand", sans-serif;
-  max-width: 900px;
-  box-shadow: 0 2px 10px rgba(255, 51, 133, 0.2);
-}
-
-.blog-title {
-  color: #ff3385;
-  font-size: 28px;
-  margin-bottom: 20px;
-  text-align: center;
-}
-
-.blog-content {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-}
-
-.blog-video iframe {
-  width: 100%;
-  height: 400px;
-  border-radius: 10px;
-}
-
-.blog-carousel {
-  display: flex;
-  overflow-x: auto;
-  gap: 10px;
-  padding-bottom: 5px;
-}
-
-.blog-carousel img {
-  height: 200px;
-  border-radius: 10px;
-  flex-shrink: 0;
-  box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
-}
-
-.blog-description {
-  background: #fff;
-  padding: 15px;
-  border-radius: 8px;
-  color: #333;
-  line-height: 1.6;
-}
-
 /* === EventPage.css === */
-.event-page {
-  text-align: center;
-  padding: 20px;
-  font-family: "Quicksand", sans-serif;
-  background-color: #fff0f6;
-}
-
 /* ========== Hero Section ========== */
 .hero {
   background: linear-gradient(to right, #ffe6f7, #ffc8ec);
@@ -482,24 +438,6 @@ code {
   box-shadow:
     0 0 15px #ff1493,
     0 0 30px #ff33aa;
-}
-
-/* ========== Section Headings ========== */
-.events-section h2,
-.registration-section h2 {
-  color: #ff3385;
-  margin-top: 40px;
-  font-size: 2rem;
-  text-shadow: 1px 1px 4px #ffc0cb;
-}
-
-/* ========== Event List Grid ========== */
-.event-list {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 20px;
-  margin-top: 20px;
 }
 
 /* ========== Registration Form ========== */
@@ -1052,175 +990,4 @@ code {
 
 .plan-form button:hover {
   background-color: #e02772;
-}
-
-/* ---------- Layout helpers ---------- */
-.section-title {
-  text-align: center;
-  font-size: 2rem;
-  margin: 0 0 1rem;
-}
-.muted {
-  opacity: 0.75;
-}
-.small {
-  font-size: 0.875rem;
-}
-.card {
-  background: #fff;
-  border-radius: 14px;
-  box-shadow:
-    0 12px 30px rgba(255, 0, 120, 0.08),
-    0 4px 14px rgba(0, 0, 0, 0.06);
-  padding: 1rem;
-}
-
-/* ---------- Hero ---------- */
-.hero--subtle {
-  background: linear-gradient(
-    180deg,
-    rgba(255, 0, 120, 0.06),
-    rgba(255, 0, 120, 0)
-  );
-  padding: 2.25rem 1rem 1rem;
-}
-.hero .hero-inner {
-  max-width: 1040px;
-  margin: 0 auto;
-  text-align: center;
-}
-
-/* ---------- Events grid ---------- */
-.event-grid {
-  max-width: 1040px;
-  margin: 0 auto;
-  display: grid;
-  gap: 20px;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  align-items: stretch;
-}
-
-/* ---------- Event card ---------- */
-.event-card {
-  background: #fff;
-  border-radius: 16px;
-  overflow: hidden;
-  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.08);
-  transition:
-    transform 0.2s ease,
-    box-shadow 0.2s ease;
-}
-.event-card:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 14px 40px rgba(0, 0, 0, 0.12);
-}
-.event-image-wrap {
-  position: relative;
-}
-.event-image {
-  width: 100%;
-  aspect-ratio: 16 / 9;
-  object-fit: cover;
-  display: block;
-}
-.event-badge {
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  padding: 6px 10px;
-  background: #ff3aa0;
-  color: #fff;
-  font-weight: 600;
-  border-radius: 999px;
-  font-size: 0.8rem;
-  box-shadow: 0 4px 10px rgba(255, 0, 160, 0.35);
-}
-.event-details {
-  padding: 14px 16px 16px;
-}
-.event-title {
-  margin: 0 0 6px;
-  font-size: 1.2rem;
-}
-.event-meta {
-  color: #5a5a5a;
-  margin-bottom: 8px;
-}
-.event-description {
-  margin: 0;
-}
-.event-tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 10px;
-}
-.event-tag {
-  display: inline-block;
-  padding: 4px 10px;
-  background: #f4e6f0;
-  color: #b3006b;
-  border-radius: 999px;
-  font-size: 0.8rem;
-  font-weight: 600;
-}
-.event-price {
-  margin-top: 12px;
-  font-weight: 700;
-  color: #b3006b;
-}
-
-/* ---------- Registration form ---------- */
-.registration-section {
-  padding: 24px 1rem 40px;
-}
-.registration-form {
-  max-width: 640px;
-  margin: 0 auto;
-  display: grid;
-  gap: 12px;
-}
-.registration-form .form-row {
-  display: grid;
-  gap: 6px;
-}
-.registration-form label {
-  font-weight: 600;
-  font-size: 0.95rem;
-}
-.registration-form input,
-.registration-form select {
-  width: 100%;
-  border: 1px solid #ffd0e6;
-  border-radius: 12px;
-  padding: 12px 14px;
-  font-size: 1rem;
-  outline: none;
-  background: #fff;
-}
-.registration-form input:focus,
-.registration-form select:focus {
-  border-color: #ff3aa0;
-  box-shadow: 0 0 0 3px rgba(255, 0, 160, 0.15);
-}
-
-.btn-primary,
-.registration-form button[type="submit"] {
-  display: inline-block;
-  margin-top: 4px;
-  background: linear-gradient(90deg, #ff3aa0, #ff6cc3);
-  color: #fff;
-  border: 0;
-  padding: 12px 18px;
-  border-radius: 999px;
-  font-weight: 700;
-  cursor: pointer;
-  transition:
-    transform 0.15s ease,
-    box-shadow 0.2s ease;
-}
-.btn-primary:hover,
-.registration-form button[type="submit"]:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 10px 24px rgba(255, 0, 160, 0.3);
 }

--- a/src/data/events.js
+++ b/src/data/events.js
@@ -2,7 +2,7 @@
 const events = [
   {
     id: "e1",
-    image: "public/Lorifitnesslogo.png",
+    image: "/Lorifitnesslogo.png",
     title: "Zumba Energy Blast",
     description: "Dance your way to fitness — outdoor session with great music.",
     date: "2025-08-16",


### PR DESCRIPTION
## Summary
- point event data image to public asset so event cards display a logo
- remove unused CSS blocks and add utility helpers for muted text, small text, and card styling

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a0c3376c3c832f877b4a605205a36e