### PR TITLE
Add serverless form endpoints and handlers

### DIFF
--- a/api/_shared/email.js
+++ b/api/_shared/email.js
@@ -1,0 +1,28 @@
+const RESEND_API_KEY = process.env.RESEND_API_KEY;
+const FORMS_SEND_TO = process.env.FORMS_SEND_TO;
+const FORMS_FROM_EMAIL = process.env.FORMS_FROM_EMAIL;
+
+async function sendEmail({ subject, text }) {
+  if (!RESEND_API_KEY || !FORMS_SEND_TO || !FORMS_FROM_EMAIL) {
+    console.warn('Missing email environment variables');
+    return;
+  }
+  const resp = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${RESEND_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from: FORMS_FROM_EMAIL,
+      to: FORMS_SEND_TO.split(',').map((s) => s.trim()),
+      subject,
+      text,
+    }),
+  });
+  if (!resp.ok) {
+    console.error('Resend API error', await resp.text());
+  }
+}
+
+module.exports = { sendEmail };

--- a/api/_shared/supabase.js
+++ b/api/_shared/supabase.js
@@ -1,0 +1,23 @@
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+async function saveToSupabase(table, data) {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+    return;
+  }
+  const resp = await fetch(`${SUPABASE_URL}/rest/v1/${table}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      apikey: SUPABASE_SERVICE_ROLE_KEY,
+      Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+      Prefer: 'return=minimal',
+    },
+    body: JSON.stringify(data),
+  });
+  if (!resp.ok) {
+    console.error('Supabase insert error', await resp.text());
+  }
+}
+
+module.exports = { saveToSupabase };

--- a/api/feedback.js
+++ b/api/feedback.js
@@ -1,0 +1,29 @@
+const { sendEmail } = require('./_shared/email');
+const { saveToSupabase } = require('./_shared/supabase');
+
+module.exports = async (req, res) => {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+  const { name, email, message, rating } = req.body || {};
+  if (!message || !rating) {
+    return res.status(400).json({ error: 'Message and rating are required' });
+  }
+  const text =
+    `New feedback` +
+    (name ? `\nName: ${name}` : '') +
+    (email ? `\nEmail: ${email}` : '') +
+    `\nRating: ${rating}` +
+    `\nMessage:\n${message}`;
+  await Promise.all([
+    sendEmail({ subject: 'New Feedback', text }),
+    saveToSupabase('feedback', {
+      name,
+      email,
+      message,
+      rating,
+    }),
+  ]);
+  res.status(200).json({ ok: true });
+};

--- a/api/newsletter.js
+++ b/api/newsletter.js
@@ -1,0 +1,19 @@
+const { sendEmail } = require('./_shared/email');
+const { saveToSupabase } = require('./_shared/supabase');
+
+module.exports = async (req, res) => {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+  const { email } = req.body || {};
+  if (!email) {
+    return res.status(400).json({ error: 'Email is required' });
+  }
+  const text = `New newsletter signup\nEmail: ${email}`;
+  await Promise.all([
+    sendEmail({ subject: 'Newsletter Signup', text }),
+    saveToSupabase('newsletter', { email }),
+  ]);
+  res.status(200).json({ ok: true });
+};

--- a/api/plans.js
+++ b/api/plans.js
@@ -1,0 +1,56 @@
+const { sendEmail } = require('./_shared/email');
+const { saveToSupabase } = require('./_shared/supabase');
+
+module.exports = async (req, res) => {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+  const {
+    name,
+    email,
+    age,
+    disliked_foods,
+    allergies,
+    meals_per_day,
+    height_cm,
+    weight_kg,
+    fitness_level,
+    goal,
+    workout_access,
+  } = req.body || {};
+
+  if (!name || !email) {
+    return res.status(400).json({ error: 'Name and email are required' });
+  }
+  const text =
+    `New plan request` +
+    `\nName: ${name}` +
+    `\nEmail: ${email}` +
+    (age ? `\nAge: ${age}` : '') +
+    (disliked_foods ? `\nDisliked foods: ${disliked_foods}` : '') +
+    (allergies ? `\nAllergies: ${allergies}` : '') +
+    (meals_per_day ? `\nMeals per day: ${meals_per_day}` : '') +
+    (height_cm ? `\nHeight cm: ${height_cm}` : '') +
+    (weight_kg ? `\nWeight kg: ${weight_kg}` : '') +
+    (fitness_level ? `\nFitness level: ${fitness_level}` : '') +
+    (goal ? `\nGoal: ${goal}` : '') +
+    (workout_access ? `\nWorkout access: ${workout_access}` : '');
+  await Promise.all([
+    sendEmail({ subject: 'New Plan Request', text }),
+    saveToSupabase('plans', {
+      name,
+      email,
+      age,
+      disliked_foods,
+      allergies,
+      meals_per_day,
+      height_cm,
+      weight_kg,
+      fitness_level,
+      goal,
+      workout_access,
+    }),
+  ]);
+  res.status(200).json({ ok: true });
+};

--- a/api/reservations.js
+++ b/api/reservations.js
@@ -1,0 +1,29 @@
+const { sendEmail } = require('./_shared/email');
+const { saveToSupabase } = require('./_shared/supabase');
+
+module.exports = async (req, res) => {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+  const { name, email, phone, eventId } = req.body || {};
+  if (!name || !email || !eventId) {
+    return res.status(400).json({ error: 'Missing required fields' });
+  }
+  const text =
+    `New reservation` +
+    `\nName: ${name}` +
+    `\nEmail: ${email}` +
+    (phone ? `\nPhone: ${phone}` : '') +
+    `\nEvent ID: ${eventId}`;
+  await Promise.all([
+    sendEmail({ subject: 'New Event Reservation', text }),
+    saveToSupabase('reservations', {
+      name,
+      email,
+      phone,
+      event_id: eventId,
+    }),
+  ]);
+  res.status(200).json({ ok: true });
+};

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,0 +1,16 @@
+async function post(url, data) {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+  return res.json();
+}
+
+export const postNewsletter = (email) => post('/api/newsletter', { email });
+export const postReservation = (data) => post('/api/reservations', data);
+export const postFeedback = (data) => post('/api/feedback', data);
+export const postPlan = (data) => post('/api/plans', data);

--- a/src/pages/Feedback.jsx
+++ b/src/pages/Feedback.jsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import '../Styles/harmonized-styles.css';
+import { postFeedback } from '../lib/api';
 
 const Feedback = () => {
   const [submitted, setSubmitted] = useState(false);
-  const [formData, setFormData] = useState({ name: '', message: '', rating: '' });
+  const [formData, setFormData] = useState({ name: '', email: '', message: '', rating: '' });
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -13,11 +14,7 @@ const Feedback = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      await fetch('/api/feedback', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(formData),
-      });
+      await postFeedback(formData);
       setSubmitted(true);
     } catch (err) {
       console.error('Feedback submit error:', err);
@@ -40,6 +37,13 @@ const Feedback = () => {
             name="name"
             placeholder="Your Name (optional)"
             value={formData.name}
+            onChange={handleChange}
+          />
+          <input
+            type="email"
+            name="email"
+            placeholder="Your Email (optional)"
+            value={formData.email}
             onChange={handleChange}
           />
           <textarea

--- a/src/pages/Footer.jsx
+++ b/src/pages/Footer.jsx
@@ -1,8 +1,21 @@
-import React from 'react';
+import React, { useState } from 'react';
 import '../Styles/harmonized-styles.css';
 import { FaInstagram, FaWhatsapp, FaTelegramPlane } from 'react-icons/fa';
+import { postNewsletter } from '../lib/api';
 
 const Footer = () => {
+  const [email, setEmail] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await postNewsletter(email);
+      setEmail('');
+    } catch (err) {
+      console.error('Newsletter submit error:', err);
+    }
+  };
+
   return (
     <footer className="footer-container">
       <div className="footer-brand">
@@ -12,8 +25,14 @@ const Footer = () => {
 
       <div className="newsletter">
         <p>Stay updated on events & wellness tips</p>
-        <form className="newsletter-form">
-          <input type="email" placeholder="Enter your email" />
+        <form className="newsletter-form" onSubmit={handleSubmit}>
+          <input
+            type="email"
+            placeholder="Enter your email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
           <button type="submit">Subscribe</button>
         </form>
       </div>

--- a/src/pages/Plans.jsx
+++ b/src/pages/Plans.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import "../Styles/harmonized-styles.css";
+import { postPlan } from "../lib/api";
 
 const Plans = () => {
   const [formData, setFormData] = useState({
@@ -26,35 +27,39 @@ const Plans = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      const res = await fetch("http://localhost:5000/api/plans", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(formData),
-      });
+      const payload = {
+        name: formData.name,
+        email: formData.email,
+        age: Number(formData.age),
+        disliked_foods: formData.dislikedFoods,
+        allergies: formData.allergies,
+        meals_per_day: Number(formData.preferredMeals),
+        height_cm: Number(formData.height),
+        weight_kg: Number(formData.weight),
+        fitness_level: formData.fitnessLevel,
+        goal: formData.goal,
+        workout_access: formData.workoutAccess,
+      };
 
-      const data = await res.json();
-      if (res.ok) {
-        alert("Thank you! Your custom plan request was submitted.");
-        console.log("Submitted data:", formData);
-        setFormData({
-          name: "",
-          email: "",
-          age: "",
-          dislikedFoods: "",
-          allergies: "",
-          preferredMeals: "",
-          height: "",
-          weight: "",
-          fitnessLevel: "",
-          goal: "",
-          workoutAccess: "",
-        });
-      } else {
-        alert("Submission failed: " + data.error);
-      }
+      await postPlan(payload);
+      alert("Thank you! Your custom plan request was submitted.");
+      console.log("Submitted data:", payload);
+      setFormData({
+        name: "",
+        email: "",
+        age: "",
+        dislikedFoods: "",
+        allergies: "",
+        preferredMeals: "",
+        height: "",
+        weight: "",
+        fitnessLevel: "",
+        goal: "",
+        workoutAccess: "",
+      });
     } catch (err) {
       console.error(err);
-      alert("Server error. Please try again.");
+      alert("Submission failed. Please try again.");
     }
   };
 


### PR DESCRIPTION
## Summary
- add Vercel serverless endpoints for newsletter, reservations, feedback, and plan requests
- wire frontend forms to new API via src/lib/api.js
- include helpers for emailing via Resend and optional Supabase logging

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a0d12f959c832f8485eeaa72e00e7f