### PR TITLE
feat: send forms via emailjs

### DIFF
--- a/src/Styles/harmonized-styles.css
+++ b/src/Styles/harmonized-styles.css
@@ -369,6 +369,17 @@ code {
 .small {
   font-size: 0.875rem;
 }
+
+.form-message {
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+}
+.form-message.success {
+  color: green;
+}
+.form-message.error {
+  color: var(--primary-color);
+}
 .card {
   background: #fff;
   border-radius: 14px;

--- a/src/lib/email.js
+++ b/src/lib/email.js
@@ -1,0 +1,18 @@
+import emailjs from 'emailjs-com';
+
+const SERVICE_ID = process.env.REACT_APP_EMAILJS_SERVICE_ID;
+const TEMPLATE_ID = process.env.REACT_APP_EMAILJS_TEMPLATE_ID;
+const PUBLIC_KEY = process.env.REACT_APP_EMAILJS_PUBLIC_KEY;
+
+export function sendEmail(params) {
+  return emailjs.send(
+    SERVICE_ID,
+    TEMPLATE_ID,
+    { to_email: 'lorimarfitness@gmail.com', ...params },
+    PUBLIC_KEY
+  );
+}
+
+export function isValidEmail(value) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}

--- a/src/pages/Feedback.jsx
+++ b/src/pages/Feedback.jsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
 import '../Styles/harmonized-styles.css';
-import { postFeedback } from '../lib/api';
+import { sendEmail, isValidEmail } from '../lib/email';
 
 const Feedback = () => {
-  const [submitted, setSubmitted] = useState(false);
   const [formData, setFormData] = useState({ name: '', email: '', message: '', rating: '' });
+  const [honeypot, setHoneypot] = useState('');
+  const [status, setStatus] = useState(null); // {type, text}
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -13,11 +14,26 @@ const Feedback = () => {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    if (honeypot) return;
+    if (
+      !formData.message ||
+      !formData.rating ||
+      (formData.email && !isValidEmail(formData.email))
+    ) {
+      setStatus({ type: 'error', text: 'Please provide a message, rating, and valid email if included.' });
+      return;
+    }
     try {
-      await postFeedback(formData);
-      setSubmitted(true);
+      await sendEmail({
+        subject: 'Site Feedback',
+        message: `Name: ${formData.name}\nEmail: ${formData.email}\nRating: ${formData.rating}\nMessage: ${formData.message}`,
+        reply_to: formData.email,
+      });
+      setStatus({ type: 'success', text: 'Thank you! Your feedback has been sent.' });
+      setFormData({ name: '', email: '', message: '', rating: '' });
     } catch (err) {
       console.error('Feedback submit error:', err);
+      setStatus({ type: 'error', text: 'Failed to send feedback. Please try again later.' });
     }
   };
 
@@ -26,52 +42,56 @@ const Feedback = () => {
       <h2 className="feedback-heading">Your voice makes us stronger 💪💗</h2>
       <p className="feedback-subtext">Leave a note, share a smile, or tell us how we can glow better together ✨</p>
 
-      {submitted ? (
-        <div className="thank-you-box">
-          <p className="thank-you-text">Thank you, gorgeous! 💖 Your feedback means the world to us 💫</p>
-        </div>
-      ) : (
-        <form className="feedback-form-girly" onSubmit={handleSubmit}>
-          <input
-            type="text"
-            name="name"
-            placeholder="Your Name (optional)"
-            value={formData.name}
-            onChange={handleChange}
-          />
-          <input
-            type="email"
-            name="email"
-            placeholder="Your Email (optional)"
-            value={formData.email}
-            onChange={handleChange}
-          />
-          <textarea
-            name="message"
-            placeholder="Tell us everything 💌"
-            rows="4"
-            required
-            value={formData.message}
-            onChange={handleChange}
-          ></textarea>
-          <select
-            name="rating"
-            value={formData.rating}
-            onChange={handleChange}
-            required
-          >
-            <option value="" disabled>
-              How are we doing? 💬
-            </option>
-            <option value="5">🌟🌟🌟🌟🌟 - Amazing!</option>
-            <option value="4">🌟🌟🌟🌟 - Great!</option>
-            <option value="3">🌟🌟🌟 - Okay</option>
-            <option value="2">🌟🌟 - Needs love</option>
-            <option value="1">🌟 - Not great</option>
-          </select>
-          <button type="submit">Send Your Love 💖</button>
-        </form>
-      )}
+      <form className="feedback-form-girly" onSubmit={handleSubmit}>
+        <input
+          type="text"
+          name="name"
+          placeholder="Your Name (optional)"
+          value={formData.name}
+          onChange={handleChange}
+        />
+        <input
+          type="email"
+          name="email"
+          placeholder="Your Email (optional)"
+          value={formData.email}
+          onChange={handleChange}
+        />
+        <textarea
+          name="message"
+          placeholder="Tell us everything 💌"
+          rows="4"
+          required
+          value={formData.message}
+          onChange={handleChange}
+        ></textarea>
+        <select
+          name="rating"
+          value={formData.rating}
+          onChange={handleChange}
+          required
+        >
+          <option value="" disabled>
+            How are we doing? 💬
+          </option>
+          <option value="5">🌟🌟🌟🌟🌟 - Amazing!</option>
+          <option value="4">🌟🌟🌟🌟 - Great!</option>
+          <option value="3">🌟🌟🌟 - Okay</option>
+          <option value="2">🌟🌟 - Needs love</option>
+          <option value="1">🌟 - Not great</option>
+        </select>
+        <input
+          type="text"
+          name="comment"
+          value={honeypot}
+          onChange={(e) => setHoneypot(e.target.value)}
+          style={{ display: 'none' }}
+          tabIndex="-1"
+          autoComplete="off"
+        />
+        <button type="submit">Send Your Love 💖</button>
+        {status && <p className={`form-message ${status.type}`}>{status.text}</p>}
+      </form>
     </section>
   );
 };


### PR DESCRIPTION
## Summary
- send all site forms via EmailJS directly
- add honeypot spam traps, validation, and user feedback messages

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a127e48c68832f83b2a889e52e17ee