### PR TITLE
Remove Supabase integration and inline EmailJS settings

### DIFF
--- a/api/_shared/email.js
+++ b/api/_shared/email.js
@@ -1,15 +1,10 @@
 const emailjs = require('@emailjs/nodejs');
 
-const SERVICE_ID = process.env.EMAILJS_SERVICE_ID;
-const TEMPLATE_ID = process.env.EMAILJS_TEMPLATE_ID;
-const PUBLIC_KEY = process.env.EMAILJS_PUBLIC_KEY;
-const PRIVATE_KEY = process.env.EMAILJS_PRIVATE_KEY;
+const SERVICE_ID = 'service_839t84l';
+const TEMPLATE_ID = 'template_lbtk24d';
+const PUBLIC_KEY = 'QYkr433CtbV-jJkbi';
 
 async function sendEmail({ subject, text }) {
-  if (!SERVICE_ID || !TEMPLATE_ID || !PUBLIC_KEY) {
-    console.warn('Missing EmailJS environment variables');
-    return;
-  }
   try {
     await emailjs.send(
       SERVICE_ID,
@@ -19,10 +14,7 @@ async function sendEmail({ subject, text }) {
         message: text,
         to_email: 'lorimarfitness@gmail.com',
       },
-      {
-        publicKey: PUBLIC_KEY,
-        privateKey: PRIVATE_KEY,
-      },
+      { publicKey: PUBLIC_KEY },
     );
   } catch (err) {
     console.error('EmailJS send error', err);

--- a/api/feedback.js
+++ b/api/feedback.js
@@ -1,5 +1,4 @@
 const { sendEmail } = require('./_shared/email');
-const { saveToSupabase } = require('./_shared/supabase');
 
 module.exports = async (req, res) => {
   if (req.method !== 'POST') {
@@ -16,14 +15,6 @@ module.exports = async (req, res) => {
     (email ? `\nEmail: ${email}` : '') +
     `\nRating: ${rating}` +
     `\nMessage:\n${message}`;
-  await Promise.all([
-    sendEmail({ subject: 'New Feedback', text }),
-    saveToSupabase('feedback', {
-      name,
-      email,
-      message,
-      rating,
-    }),
-  ]);
+  await sendEmail({ subject: 'New Feedback', text });
   res.status(200).json({ ok: true });
 };

--- a/api/newsletter.js
+++ b/api/newsletter.js
@@ -1,5 +1,4 @@
 const { sendEmail } = require('./_shared/email');
-const { saveToSupabase } = require('./_shared/supabase');
 
 module.exports = async (req, res) => {
   if (req.method !== 'POST') {
@@ -11,9 +10,6 @@ module.exports = async (req, res) => {
     return res.status(400).json({ error: 'Email is required' });
   }
   const text = `New newsletter signup\nEmail: ${email}`;
-  await Promise.all([
-    sendEmail({ subject: 'Newsletter Signup', text }),
-    saveToSupabase('newsletter', { email }),
-  ]);
+  await sendEmail({ subject: 'Newsletter Signup', text });
   res.status(200).json({ ok: true });
 };

--- a/api/plans.js
+++ b/api/plans.js
@@ -1,5 +1,4 @@
 const { sendEmail } = require('./_shared/email');
-const { saveToSupabase } = require('./_shared/supabase');
 
 module.exports = async (req, res) => {
   if (req.method !== 'POST') {
@@ -36,21 +35,6 @@ module.exports = async (req, res) => {
     (fitness_level ? `\nFitness level: ${fitness_level}` : '') +
     (goal ? `\nGoal: ${goal}` : '') +
     (workout_access ? `\nWorkout access: ${workout_access}` : '');
-  await Promise.all([
-    sendEmail({ subject: 'New Plan Request', text }),
-    saveToSupabase('plans', {
-      name,
-      email,
-      age,
-      disliked_foods,
-      allergies,
-      meals_per_day,
-      height_cm,
-      weight_kg,
-      fitness_level,
-      goal,
-      workout_access,
-    }),
-  ]);
+  await sendEmail({ subject: 'New Plan Request', text });
   res.status(200).json({ ok: true });
 };

--- a/api/reservations.js
+++ b/api/reservations.js
@@ -1,5 +1,4 @@
 const { sendEmail } = require('./_shared/email');
-const { saveToSupabase } = require('./_shared/supabase');
 
 module.exports = async (req, res) => {
   if (req.method !== 'POST') {
@@ -16,14 +15,6 @@ module.exports = async (req, res) => {
     `\nEmail: ${email}` +
     (phone ? `\nPhone: ${phone}` : '') +
     `\nEvent ID: ${eventId}`;
-  await Promise.all([
-    sendEmail({ subject: 'New Event Reservation', text }),
-    saveToSupabase('reservations', {
-      name,
-      email,
-      phone,
-      event_id: eventId,
-    }),
-  ]);
+  await sendEmail({ subject: 'New Event Reservation', text });
   res.status(200).json({ ok: true });
 };

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,0 @@
-PORT=5000
-CLIENT_ORIGIN=https://your-production-origin.com
-MONGO_URI=mongodb://127.0.0.1:27017/lorimar
-EMAIL_USER=your-email@example.com
-EMAIL_PASS=your-email-password
-EMAIL_TO=recipient@example.com

--- a/src/lib/email.js
+++ b/src/lib/email.js
@@ -1,24 +1,3 @@
-import emailjs from 'emailjs-com';
-
-const SERVICE_ID = process.env.REACT_APP_EMAILJS_SERVICE_ID;
-const TEMPLATE_ID = process.env.REACT_APP_EMAILJS_TEMPLATE_ID;
-const PUBLIC_KEY = process.env.REACT_APP_EMAILJS_PUBLIC_KEY;
-
-export function sendEmail(params) {
-  return emailjs.send(
-    SERVICE_ID,
-    TEMPLATE_ID,
-    { to_email: 'lorimarfitness@gmail.com', ...params },
-    PUBLIC_KEY
-  );
-}
-
 export function isValidEmail(value) {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
 }
-
-console.log('ENV CHECK', {
-  SERVICE_ID: process.env.REACT_APP_EMAILJS_SERVICE_ID,
-  TEMPLATE_ID: process.env.REACT_APP_EMAILJS_TEMPLATE_ID,
-  PUBLIC_KEY: process.env.REACT_APP_EMAILJS_PUBLIC_KEY ? 'present' : 'MISSING'
-});

--- a/src/pages/EventPage.jsx
+++ b/src/pages/EventPage.jsx
@@ -2,7 +2,12 @@ import React, { useMemo, useState } from "react";
 import "../Styles/harmonized-styles.css";
 import EventCard from "../components/EventCard/EventCard";
 import eventsData from "../data/events";
-import { sendEmail, isValidEmail } from "../lib/email";
+import emailjs from 'emailjs-com';
+import { isValidEmail } from "../lib/email";
+
+const SERVICE_ID = 'service_839t84l';
+const TEMPLATE_ID = 'template_lbtk24d';
+const PUBLIC_KEY = 'QYkr433CtbV-jJkbi';
 
 const sortEvents = (arr) =>
   [...arr].sort((a, b) => {
@@ -37,11 +42,17 @@ export default function EventPage() {
     }
 
     try {
-      await sendEmail({
-        subject: "Event Reservation",
-        message: `Name: ${form.name}\nEmail: ${form.email}\nPhone: ${form.phone}\nEvent: ${selected.title}`,
-        reply_to: form.email,
-      });
+      await emailjs.send(
+        SERVICE_ID,
+        TEMPLATE_ID,
+        {
+          to_email: 'lorimarfitness@gmail.com',
+          subject: 'Event Reservation',
+          message: `Name: ${form.name}\nEmail: ${form.email}\nPhone: ${form.phone}\nEvent: ${selected.title}`,
+          reply_to: form.email,
+        },
+        PUBLIC_KEY,
+      );
       setStatus({ type: "success", text: "Reservation submitted! We'll be in touch soon." });
       setForm({ name: "", email: "", phone: "", eventId: events[0]?.id || "" });
     } catch (err) {

--- a/src/pages/Feedback.jsx
+++ b/src/pages/Feedback.jsx
@@ -1,6 +1,11 @@
 import React, { useState } from 'react';
 import '../Styles/harmonized-styles.css';
-import { sendEmail, isValidEmail } from '../lib/email';
+import emailjs from 'emailjs-com';
+import { isValidEmail } from '../lib/email';
+
+const SERVICE_ID = 'service_839t84l';
+const TEMPLATE_ID = 'template_lbtk24d';
+const PUBLIC_KEY = 'QYkr433CtbV-jJkbi';
 
 const Feedback = () => {
   const [formData, setFormData] = useState({ name: '', email: '', message: '', rating: '' });
@@ -24,11 +29,17 @@ const Feedback = () => {
       return;
     }
     try {
-      await sendEmail({
-        subject: 'Site Feedback',
-        message: `Name: ${formData.name}\nEmail: ${formData.email}\nRating: ${formData.rating}\nMessage: ${formData.message}`,
-        reply_to: formData.email,
-      });
+      await emailjs.send(
+        SERVICE_ID,
+        TEMPLATE_ID,
+        {
+          to_email: 'lorimarfitness@gmail.com',
+          subject: 'Site Feedback',
+          message: `Name: ${formData.name}\nEmail: ${formData.email}\nRating: ${formData.rating}\nMessage: ${formData.message}`,
+          reply_to: formData.email,
+        },
+        PUBLIC_KEY,
+      );
       setStatus({ type: 'success', text: 'Thank you! Your feedback has been sent.' });
       setFormData({ name: '', email: '', message: '', rating: '' });
     } catch (err) {

--- a/src/pages/Footer.jsx
+++ b/src/pages/Footer.jsx
@@ -1,7 +1,12 @@
 import React, { useState } from 'react';
 import '../Styles/harmonized-styles.css';
 import { FaInstagram, FaWhatsapp, FaTelegramPlane } from 'react-icons/fa';
-import { sendEmail, isValidEmail } from '../lib/email';
+import emailjs from 'emailjs-com';
+import { isValidEmail } from '../lib/email';
+
+const SERVICE_ID = 'service_839t84l';
+const TEMPLATE_ID = 'template_lbtk24d';
+const PUBLIC_KEY = 'QYkr433CtbV-jJkbi';
 
 const Footer = () => {
   const [email, setEmail] = useState('');
@@ -16,11 +21,17 @@ const Footer = () => {
       return;
     }
     try {
-      await sendEmail({
-        subject: 'Newsletter Subscription',
-        message: `New subscriber: ${email}`,
-        reply_to: email,
-      });
+      await emailjs.send(
+        SERVICE_ID,
+        TEMPLATE_ID,
+        {
+          to_email: 'lorimarfitness@gmail.com',
+          subject: 'Newsletter Subscription',
+          message: `New subscriber: ${email}`,
+          reply_to: email,
+        },
+        PUBLIC_KEY,
+      );
       setEmail('');
       setStatus({ type: 'success', text: 'Thanks for subscribing!' });
     } catch (err) {

--- a/src/pages/Plans.jsx
+++ b/src/pages/Plans.jsx
@@ -1,6 +1,11 @@
 import React, { useState } from "react";
 import "../Styles/harmonized-styles.css";
-import { sendEmail, isValidEmail } from "../lib/email";
+import emailjs from 'emailjs-com';
+import { isValidEmail } from "../lib/email";
+
+const SERVICE_ID = 'service_839t84l';
+const TEMPLATE_ID = 'template_lbtk24d';
+const PUBLIC_KEY = 'QYkr433CtbV-jJkbi';
 
 const Plans = () => {
   const [formData, setFormData] = useState({
@@ -47,11 +52,17 @@ const Plans = () => {
     try {
       const message = `Name: ${formData.name}\nEmail: ${formData.email}\nAge: ${formData.age}\nHeight: ${formData.height}\nWeight: ${formData.weight}\nFitness Level: ${formData.fitnessLevel}\nGoal: ${formData.goal}\nWorkout Access: ${formData.workoutAccess}\nDisliked Foods: ${formData.dislikedFoods}\nAllergies: ${formData.allergies}\nMeals per day: ${formData.preferredMeals}`;
 
-      await sendEmail({
-        subject: "Plan Request",
-        message,
-        reply_to: formData.email,
-      });
+      await emailjs.send(
+        SERVICE_ID,
+        TEMPLATE_ID,
+        {
+          to_email: 'lorimarfitness@gmail.com',
+          subject: 'Plan Request',
+          message,
+          reply_to: formData.email,
+        },
+        PUBLIC_KEY,
+      );
       setStatus({ type: "success", text: "Thank you! Your custom plan request was submitted." });
       setFormData({
         name: "",


### PR DESCRIPTION
## Summary
- hardcode EmailJS service, template and public key in all page forms
- drop Supabase persistence and env variables from API handlers
- simplify email helper to only validate addresses

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a20e673504832fbf9bc4d6552276fa